### PR TITLE
feat: make Telegram notifications silent

### DIFF
--- a/packages/uptime-worker/src/services/TelegramService.ts
+++ b/packages/uptime-worker/src/services/TelegramService.ts
@@ -17,11 +17,12 @@ export class TelegramService {
     message: string;
     options?: Pick<
       Parameters<ApiMethods["sendMessage"]>[0],
-      "reply_parameters"
+      "reply_parameters" | "disable_notification"
     >;
   }) {
     return this.bot.api.sendMessage(chatId, message, {
       parse_mode: "Markdown",
+      disable_notification: true,
       ...options,
     });
   }


### PR DESCRIPTION
Added `disable_notification: true` to `TelegramService.sendMessage()` so uptime alerts don't produce notification sounds/vibrations.

**Changes:**
- Updated `TelegramService.ts` to include `disable_notification: true` by default
- Extended options type to allow overriding this setting if needed