### PR TITLE
chore: remove Rancher and Syncthing checks from config

### DIFF
--- a/packages/uptime-worker/uptime.config.ts
+++ b/packages/uptime-worker/uptime.config.ts
@@ -17,12 +17,6 @@ export const uptimeWorkerConfig: UptimeWorkerConfig = {
   statuspageUrl: "https://hobroker.statuspage.io",
   checks: [
     {
-      name: "Rancher",
-      target: "https://rancher.hobroker.me",
-      headers: zeroTrustAuth,
-      retryCount: 1,
-    },
-    {
       name: "Sonarr",
       target: "https://sonarr.hobroker.me",
       headers: zeroTrustAuth,
@@ -55,12 +49,6 @@ export const uptimeWorkerConfig: UptimeWorkerConfig = {
     {
       name: "VS Code",
       target: "https://code.hobroker.me",
-      headers: zeroTrustAuth,
-      retryCount: 1,
-    },
-    {
-      name: "Syncthing",
-      target: "https://syncthing.hobroker.me",
       headers: zeroTrustAuth,
       retryCount: 1,
     },

--- a/packages/uptime-worker/uptime.config.ts
+++ b/packages/uptime-worker/uptime.config.ts
@@ -53,12 +53,6 @@ export const uptimeWorkerConfig: UptimeWorkerConfig = {
       retryCount: 1,
     },
     {
-      name: "n8n",
-      target: "https://n8n.hobroker.me",
-      headers: zeroTrustAuth,
-      retryCount: 1,
-    },
-    {
       name: "http-echos-echo",
       target: "https://demo.hobroker.me",
       headers: zeroTrustAuth,


### PR DESCRIPTION
Removed checks for Rancher and Syncthing from uptime configuration.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wow... look at all these changes! Man, I tell ya, sometimes you gotta prune the crop — just like at Tegridy Farms. This PR removes the uptime monitoring checks for **Rancher** and **Syncthing** from `uptime.config.ts`, presumably because those services are no longer being run or need monitoring.

- Removes the `"Rancher"` check targeting `https://rancher.hobroker.me`
- Removes the `"Syncthing"` check targeting `https://syncthing.hobroker.me`
- The remaining 8 checks and overall config structure are valid and unaffected
- No logic, syntax, or functional issues introduced

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge — it's a clean removal of two config entries with no side effects.
- The change is a straightforward deletion of two monitoring check objects from a configuration array. No logic is altered, no imports are affected, and the remaining config remains syntactically and semantically valid. There is nothing here that could introduce a bug or regression.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/uptime-worker/uptime.config.ts | Removes two uptime check entries — "Rancher" and "Syncthing" — from the checks array. The remaining config is valid and well-formed. |

</details>

</details>

<sub>Last reviewed commit: 159ec13</sub>

<!-- /greptile_comment -->